### PR TITLE
fix: remove the error message where it prints your api key

### DIFF
--- a/pkg/request/request.go
+++ b/pkg/request/request.go
@@ -64,7 +64,6 @@ func RequestApi(gitDiff string, model Model, maxtokens int, temperature float64,
 	improvements, err := RequestImprovements(globals.OpenaiKey, gitDiff, model, maxtokens, temperature, top_p, frequence, presence, bestof)
 	if err != nil {
 		globals.Log.Error().
-            Str("Open API Key", globals.OpenaiKey).
             Str("Model", model).
             Int("Max Tokens", maxtokens).
             Float64("Temperature", temperature).


### PR DESCRIPTION
remove the part where it prints your api key for security